### PR TITLE
examples: use proto/jsonpb instead of encoding/json

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,15 @@ as OpenCensus-Proto.
 The reason for its existence to gut out the gRPC
 dependencies in order for golang.org/x/tools/*
 to use OpenCensus and have performance monitoring.
+
+## Note
+
+Make sure to use
+
+    `"github.com/golang/protobuf/jsonpb"`
+
+instead of
+
+    `"encoding/json"`
+
+for JSON serialization of Proto messages.


### PR DESCRIPTION
In the past we just used the grpc-gateway to transform
messages and send them as JSON to the agent.

However, since we are now sending plain messages and have
to do the work ourselves, we have to send JSON serialized
messages after using

    "github.com/golang/protobuf/jsonpb"

instead of

    "encoding/json"

Fixes #1